### PR TITLE
Allow Rails 7

### DIFF
--- a/wallaby-view.gemspec
+++ b/wallaby-view.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
   ]
   spec.require_paths = ['lib']
 
-  spec.add_dependency 'railties', '>= 4.2.0', '<= 6.2.0'
+  spec.add_dependency 'railties', '>= 4.2.0'
 
   spec.add_development_dependency 'github-markup'
   spec.add_development_dependency 'minitest-rails'


### PR DESCRIPTION
This removes the `<= 6.2.0` Rails version dependency to allow for Rails 7. Everything appears to work so far in my testing.